### PR TITLE
Update botaccount script to use Create2, make botaccountfactory script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,8 @@ out/
 /broadcast/*/31337/
 /broadcast/**/dry-run/
 
+# Ignore all script inputs such as CREATE2 salts
+script/input
+
 # Dotenv file
 .env*

--- a/examples.txt
+++ b/examples.txt
@@ -2,10 +2,10 @@ Deploy and verify ERC721Mage from CLI:
 source .env
 forge create --private-key $PRIVATE_KEY --verify --chain-id 5 --rpc-url $GOERLI_RPC_URL --api-key $ETHERSCAN_API_KEY src/cores/ERC721/ERC721Mage.sol:ERC721Mage
 
-Deploy and verify BotAccounts via script:
+Deploy and verify BotAccounts via script (using keystore in path `~/.foundry/keystores/beef`, which contains private key for `0xbeef47cd2ce1c287982d8bf7a06870744bd18112`, using decryption password `somepass`):
 ```
 source .env
-forge script script/BotAccount.s.sol:BotAccountScript --rpc-url $GOERLI_RPC_URL --chain-id 5 --broadcast --etherscan-api-key $ETHERSCAN_API_KEY --verify -vvvv
+forge script script/BotAccount.s.sol:BotAccountScript --keystore ~/.foundry/keystores/beef --password somepass --sender 0xbeef47cd2ce1c287982d8bf7a06870744bd18112 --rpc-url $GOERLI_RPC_URL --chain-id 5 --broadcast --etherscan-api-key $ETHERSCAN_API_KEY --verify -vvvv
 ```
 
 From CLI:

--- a/examples.txt
+++ b/examples.txt
@@ -2,7 +2,7 @@ Deploy and verify ERC721Mage from CLI:
 source .env
 forge create --private-key $PRIVATE_KEY --verify --chain-id 5 --rpc-url $GOERLI_RPC_URL --api-key $ETHERSCAN_API_KEY src/cores/ERC721/ERC721Mage.sol:ERC721Mage
 
-Deploy and verify BotAccounts via script (using keystore in path `~/.foundry/keystores/beef`, which contains private key for `0xbeef47cd2ce1c287982d8bf7a06870744bd18112`, using decryption password `somepass`):
+Deploy and verify BotAccounts via script (using keystore at path `~/.foundry/keystores/beef`, which contains private key for `0xbeef47cd2ce1c287982d8bf7a06870744bd18112`, using decryption password `somepass`):
 ```
 source .env
 forge script script/BotAccount.s.sol:BotAccountScript --keystore ~/.foundry/keystores/beef --password somepass --sender 0xbeef47cd2ce1c287982d8bf7a06870744bd18112 --rpc-url $GOERLI_RPC_URL --chain-id 5 --broadcast --etherscan-api-key $ETHERSCAN_API_KEY --verify -vvvv

--- a/foundry.toml
+++ b/foundry.toml
@@ -12,6 +12,6 @@ remappings = [
 ]
 
 # Configures permissions for cheatcodes that touch the filesystem like `vm.readFile`
-fs_permissions = [{ access = "read", path = "./script/input" }]
+fs_permissions = [{ access = "read-write", path = "./script/input" }]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/foundry.toml
+++ b/foundry.toml
@@ -11,4 +11,7 @@ remappings = [
     'openzeppelin/=lib/openzeppelin-contracts/contracts/',
 ]
 
+# Configures permissions for cheatcodes that touch the filesystem like `vm.readFile`
+fs_permissions = [{ access = "read", path = "./script/input" }]
+
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/script/BotAccount.s.sol
+++ b/script/BotAccount.s.sol
@@ -6,6 +6,7 @@ import {CallPermitValidator} from "src/validator/CallPermitValidator.sol";
 import {BotAccount} from "src/cores/account/BotAccount.sol";
 import {BotAccountFactory} from "src/cores/account/factory/BotAccountFactory.sol";
 import {ERC1967Proxy} from "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {Strings} from "openzeppelin-contracts/utils/Strings.sol";
 
 /// @dev Script to deploy new implementations of BotAccount.sol and CallPermitValidator.sol only.
 /// To deploy a factory enabling permissionless creation of proxy accounts, see BotAccountFactory.s.sol
@@ -50,7 +51,11 @@ contract BotAccountScript is ScriptUtils {
         botAccountProxy.initialize(owner, address(callPermitValidator), turnkeys);
         
         // the two previous calls are external so they are broadcast as separate txs; thus check state externally
-        if (!botAccountProxy.initialized()) revert Create2Failure(); 
+        if (!botAccountProxy.initialized()) revert Create2Failure();
+
+        writeUsedSalt(saltString, string.concat("CallPermitValidator @", Strings.toHexString(address(callPermitValidator))));
+        writeUsedSalt(saltString, string.concat("BotAccountImpl @", Strings.toHexString(address(botAccountImpl))));
+        writeUsedSalt(saltString, string.concat("BotAccountProxy @", Strings.toHexString(address(botAccountImpl))));
 
         vm.stopBroadcast();
     }

--- a/script/BotAccountFactory.s.sol
+++ b/script/BotAccountFactory.s.sol
@@ -6,6 +6,7 @@ import {CallPermitValidator} from "src/validator/CallPermitValidator.sol";
 import {BotAccount} from "src/cores/account/BotAccount.sol";
 import {BotAccountFactory} from "src/cores/account/factory/BotAccountFactory.sol";
 import {ERC1967Proxy} from "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {Strings} from "openzeppelin-contracts/utils/Strings.sol";
 
 /// @dev Script to deploy the BotAccountFactory to enable permissionless creation of BotAccounts 
 /// Creates a CallPermitValidator and the BotAccountFactory implementation and proxy.
@@ -66,6 +67,11 @@ contract BotAccountFactoryScript is ScriptUtils {
         //     address(callPermitValidator), 
         //     turnkeys
         // )));
+
+        writeUsedSalt(saltString, string.concat("BotAccountFactoryImpl @", Strings.toHexString(address(botAccountFactoryImpl))));
+        writeUsedSalt(saltString, string.concat("BotAccountFactoryProxy @", Strings.toHexString(address(botAccountFactoryProxy))));
+        writeUsedSalt(saltString, string.concat("CallPermitValidator @", Strings.toHexString(address(callPermitValidator))));
+        writeUsedSalt(saltString, string.concat("BotAccountImpl @", Strings.toHexString(address(botAccountImpl))));
 
         vm.stopBroadcast();
     }

--- a/script/BotAccountFactory.s.sol
+++ b/script/BotAccountFactory.s.sol
@@ -7,9 +7,10 @@ import {BotAccount} from "src/cores/account/BotAccount.sol";
 import {BotAccountFactory} from "src/cores/account/factory/BotAccountFactory.sol";
 import {ERC1967Proxy} from "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
-/// @dev Script to deploy new implementations of BotAccount.sol and CallPermitValidator.sol only.
-/// To deploy a factory enabling permissionless creation of proxy accounts, see BotAccountFactory.s.sol
-contract BotAccountScript is ScriptUtils {
+/// @dev Script to deploy the BotAccountFactory to enable permissionless creation of BotAccounts 
+/// Creates a CallPermitValidator and the BotAccountFactory implementation and proxy.
+/// To deploy standalone BotAccounts, see BotAccount.s.sol
+contract BotAccountFactoryScript is ScriptUtils {
     function run() public {
 
         /*=================
@@ -17,9 +18,10 @@ contract BotAccountScript is ScriptUtils {
         =================*/
 
         /// @dev The following contracts will be deployed and initialized by this script
+        BotAccountFactory botAccountFactoryImpl;
+        BotAccountFactory botAccountFactoryProxy;
         CallPermitValidator callPermitValidator;
         BotAccount botAccountImpl;
-        BotAccount botAccountProxy;
         
         // uncomment all instances of `deployerPrivateKey` if using a private key in shell env var
         // uint256 deployerPrivateKey = vm.envUint("PK");
@@ -42,15 +44,28 @@ contract BotAccountScript is ScriptUtils {
         // deploy turnkeyValidator
         callPermitValidator = new CallPermitValidator{salt: salt}(entryPointAddress);
 
-        // deploy botAccountImpl, `_disableInitializers()` called in constructor
+        // deploy botAccountImpl for the factory to use
         botAccountImpl = new BotAccount{salt: salt}(entryPointAddress);
 
-        // deploy and initialize the botAccountProxy
-        botAccountProxy = BotAccount(payable(address(new ERC1967Proxy{salt: salt}(address(botAccountImpl), ''))));
-        botAccountProxy.initialize(owner, address(callPermitValidator), turnkeys);
-        
-        // the two previous calls are external so they are broadcast as separate txs; thus check state externally
-        if (!botAccountProxy.initialized()) revert Create2Failure(); 
+        // deploy factoryImpl
+        botAccountFactoryImpl = new BotAccountFactory{salt: salt}();
+
+        // craft initData for factoryProxy
+        bytes memory botAccountFactoryInitData = abi.encodeWithSelector(
+            BotAccountFactory.initialize.selector, 
+            address(botAccountImpl), 
+            owner 
+        );
+        // deploy factoryProxy
+        botAccountFactoryProxy = BotAccountFactory(address(new ERC1967Proxy(address(botAccountFactoryImpl), botAccountFactoryInitData)));
+
+        // Now anyone can permissionlessly deploy a BotAccount like so:
+        // BotAccount(payable(botAccountFactoryProxy.createBotAccount(
+        //     salt, 
+        //     owner,
+        //     address(callPermitValidator), 
+        //     turnkeys
+        // )));
 
         vm.stopBroadcast();
     }

--- a/script/utils/ScriptUtils.sol
+++ b/script/utils/ScriptUtils.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+// import {stdJson as vm} from "forge-std/StdJson.sol";
+// import {Vm} from "forge-std/Vm.sol";
+import {Script} from "forge-std/Script.sol";
+
+abstract contract ScriptUtils is Script {
+    error Create2Failure();
+
+    // global addresses
+    address public constant MAX_ADDRESS = 0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF;
+    // most recent version across goerli, polygon, optimism, arbitrum, mainnet as of 09/14/23
+    address public constant entryPointAddress = 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789;
+
+    // valid as of 09/14/23
+    address public constant turnkey = 0xBb942519A1339992630b13c3252F04fCB09D4841;
+
+    // dev addresses
+    address public constant symmetry = 0x7ff6363cd3A4E7f9ece98d78Dd3c862bacE2163d;
+    address public constant frog = 0xE7affDB964178261Df49B86BFdBA78E9d768Db6D;
+    address public constant paprika = 0x4b8c47aE2e5083EE6AA9aE2884E8051c2e4741b1;
+    address public constant robriks = 0xFFFFfFfFA2eC6F66a22017a0Deb0191e5F8cBc35;
+
+    // reads a plain extensionless file containing *only the salt string* 
+    function readSalt(string memory fileName) internal view returns (string memory) {
+        string memory inputDir = "./script/input/";
+        string memory file = string.concat(inputDir, fileName);
+        return vm.readFile(file);
+    }
+}

--- a/script/utils/ScriptUtils.sol
+++ b/script/utils/ScriptUtils.sol
@@ -28,4 +28,11 @@ abstract contract ScriptUtils is Script {
         string memory file = string.concat(inputDir, fileName);
         return vm.readFile(file);
     }
+
+    // write used salts to an output file upon completion of scripts that used `readSalt()`
+    function writeUsedSalt(string memory consumedSalt, string memory deployment) internal {
+        string memory output = string.concat(consumedSalt, " : ", deployment, ", "); // eg. "GarlicSalt : ERC721Mage, "
+        string memory dest = "./script/input/usedSalts";
+        return vm.writeLine(dest, output);
+    }
 }

--- a/src/cores/account/BotAccount.sol
+++ b/src/cores/account/BotAccount.sol
@@ -84,8 +84,6 @@ contract BotAccount is Account, Ownable, Initializable {
         return true;
     }
 
-
-
     /// @notice This function must be overridden by contracts inheriting `Account` to delineate 
     /// the type of Account: `Bot`, `Member`, or `Group`
     /// @dev Owner stored explicitly using OwnableStorage's ERC7201 namespace

--- a/src/cores/account/factory/AccountFactory.sol
+++ b/src/cores/account/factory/AccountFactory.sol
@@ -46,28 +46,6 @@ abstract contract AccountFactory is Ownable, IAccountFactory {
         emit AccountImplUpdated(_newAccountImpl);
     }
 
-    /** @notice To help visualize the bytes constructed using Yul assembly, here is a deconstructed rundown
-    .  For the following hypothetical values. Active memory is shown with a preceding arrow: `->`
-    .   `address(this) = 0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef`
-    .   `salt = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff`
-    .   `creationCodeHash = 0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddead`
-    .  Load 32-byte word at free memory pointer: ```let ptr := mload(0x40)```
-    .    -> 0x0000000000000000000000000000000000000000000000000000000000000000
-    .  Store 1-byte create2 constant at 11th index: ```mstore(add(ptr, 0x0b), 0xff)```
-    .    -> 0x0000000000000000000000FF0000000000000000000000000000000000000000
-    .  Store 20-byte address of deployer (this contract) at 12th index: ```mstore(ptr, address(this)) ```
-    .    -> 0x0000000000000000000000FFbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef
-    .  Store 32-byte salt at 32nd index, creating a second word: ```mstore(add(ptr, 0x20), salt)```
-    .    -> 0x0000000000000000000000FFbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef
-    .    -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    .  Store 32-byte creationCodeHash at 64th index, creating a third word: ```mstore(add(ptr, 0x40), creationCodeHash)```
-    .    -> 0x0000000000000000000000FFbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef
-    .    -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    .    -> 0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddead
-    .  Keccak256 hash above memory layout, ignoring the first 11 empty bytes: ```keccak256(add(ptr, 0x0b), 85)```
-    .    -> bytes32(0x...SomeKeccakOutput...)
-    .  Solidity automatically discards the last 12 bytes of the 32-byte Keccak output above, leaving a 20-byte address
-    */
     function _simulateCreate2(
         bytes32 _salt, 
         bytes32 _creationCodeHash


### PR DESCRIPTION
Introduce CreateUtils, which stores relevant data across all deployments as well as provides a basic, `.gitignore`-protected way to manage salts and informally store used ones