### PR TITLE
Fix missing `ERC165::supportsInterface()` in ERC20rails

### DIFF
--- a/src/cores/ERC20/ERC20.sol
+++ b/src/cores/ERC20/ERC20.sol
@@ -55,6 +55,15 @@ abstract contract ERC20 is IERC20 {
         return true;
     }
 
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        // The interface IDs are constants representing the first 4 bytes
+        // of the XOR of all function selectors in the interface.
+        // See: [ERC165](https://eips.ethereum.org/EIPS/eip-165)
+        // (e.g. `bytes4(i.functionA.selector ^ i.functionB.selector ^ ...)`)
+        return interfaceId == 0x01ffc9a7 // ERC165 interface ID for ERC165.
+            || interfaceId == type(IERC20).interfaceId; // ERC165 interface ID for ERC20.
+    }
+
     function _transfer(address from, address to, uint256 value) internal {
         if (from == address(0)) {
             revert ERC20InvalidSender(address(0));

--- a/src/cores/ERC20/ERC20Rails.sol
+++ b/src/cores/ERC20/ERC20Rails.sol
@@ -62,6 +62,11 @@ contract ERC20Rails is Rails, Ownable, Initializable, TokenMetadata, ERC20, IERC
         METADATA
     ==============*/
 
+    /// @inheritdoc Rails
+    function supportsInterface(bytes4 interfaceId) public view override(Rails, ERC20) returns (bool) {
+        return Rails.supportsInterface(interfaceId) || ERC20.supportsInterface(interfaceId);
+    }
+
     /// @dev Function to return the name of a token implementation
     /// @return _ The returned ERC20 name string
     function name() public view override(IERC20, TokenMetadataInternal) returns (string memory) {

--- a/src/extension/examples/metadataRouter/MetadataRouterExtensionData.sol
+++ b/src/extension/examples/metadataRouter/MetadataRouterExtensionData.sol
@@ -9,7 +9,7 @@ abstract contract MetadataRouterExtensionData {
 }
 
 library MetadataRouterStorage {
-    bytes32 public constant STORAGE_POSITION = keccak256("0xrails.extensions.metadataRouter.storage");
+    bytes32 public constant STORAGE_POSITION = keccak256(abi.encode(uint256(keccak256("0xrails.Extensions.MetadataRouterData")) -1));
 
     struct Data {
         address metadataRouter;


### PR DESCRIPTION
Added missing `supportsInterface()` functionality to ERC20Rails and parent namespaced ERC20 contract