### PR TITLE
Erc721 refactor

### DIFF
--- a/src/cores/ERC721/ERC721.sol
+++ b/src/cores/ERC721/ERC721.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {IERC721External} from "./interface/IERC721.sol";
+import {IERC721} from "./interface/IERC721.sol";
 import {ERC721Internal} from "./ERC721Internal.sol";
 import {ERC721Storage} from "./ERC721Storage.sol";
 
-abstract contract ERC721 is ERC721Internal, IERC721External {
+abstract contract ERC721 is ERC721Internal {
     /*===========
         VIEWS
     ===========*/
@@ -27,6 +27,46 @@ abstract contract ERC721 is ERC721Internal, IERC721External {
         return interfaceId == 0x01ffc9a7 // ERC165 interface ID for ERC165.
             || interfaceId == 0x80ac58cd // ERC165 interface ID for ERC721.
             || interfaceId == 0x5b5e139f; // ERC165 interface ID for ERC721Metadata.
+    }
+
+    /*===========
+        VIEWS
+    ===========*/
+
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply();
+    }
+
+    function balanceOf(address owner) public view virtual override returns (uint256) {
+        return _balanceOf(owner);
+    }
+
+    function ownerOf(uint256 tokenId) public view virtual returns (address) {
+        return _ownerOf(tokenId);
+    }
+
+    function getApproved(uint256 tokenId) public view virtual returns (address) {
+        return _getApproved(tokenId);
+    }
+
+    function isApprovedForAll(address owner, address operator) public view virtual returns (bool) {
+        return _isApprovedForAll(owner, operator);
+    }
+
+    function totalMinted() public view virtual override returns (uint256) {
+        return _totalMinted();
+    }
+
+    function totalBurned() public view virtual override returns (uint256) {
+        return _totalBurned();
+    }
+
+    function numberMinted(address owner) public view override returns (uint256) {
+        return _numberMinted(owner);
+    }
+
+    function numberBurned(address owner) public view override returns (uint256) {
+        return _numberBurned(owner);
     }
 
     /*=============
@@ -55,8 +95,4 @@ abstract contract ERC721 is ERC721Internal, IERC721External {
         transferFrom(from, to, tokenId);
         _checkOnERC721Received(from, to, tokenId, data);
     }
-
-    /*====================
-        AUTHORIZATION
-    ====================*/
 }

--- a/src/cores/ERC721/ERC721Internal.sol
+++ b/src/cores/ERC721/ERC721Internal.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.13;
 
 import {Initializable} from "../../lib/initializable/Initializable.sol";
-import {IERC721Internal, IERC721Receiver} from "./interface/IERC721.sol";
+import {IERC721, IERC721Receiver} from "./interface/IERC721.sol";
 import {ERC721Storage} from "./ERC721Storage.sol";
 
-abstract contract ERC721Internal is Initializable, IERC721Internal {
+abstract contract ERC721Internal is Initializable, IERC721 {
     /*=================
         INITIALIZER
     =================*/
@@ -30,42 +30,42 @@ abstract contract ERC721Internal is Initializable, IERC721Internal {
         return layout.currentIndex;
     }
 
-    function totalSupply() public view virtual returns (uint256) {
+    function _totalSupply() internal view returns (uint256) {
         ERC721Storage.Layout storage layout = ERC721Storage.layout();
         return layout.currentIndex - layout.burnCounter - _startTokenId();
     }
 
-    function totalMinted() public view virtual returns (uint256) {
+    function _totalMinted() internal view returns (uint256) {
         ERC721Storage.Layout storage layout = ERC721Storage.layout();
         return layout.currentIndex - _startTokenId();
     }
 
-    function totalBurned() public view virtual returns (uint256) {
+    function _totalBurned() internal view returns (uint256) {
         ERC721Storage.Layout storage layout = ERC721Storage.layout();
         return layout.burnCounter;
     }
 
     // owner values
 
-    function balanceOf(address owner) public view virtual returns (uint256) {
+    function _balanceOf(address owner) internal view returns (uint256) {
         if (owner == address(0)) revert BalanceQueryForZeroAddress();
         ERC721Storage.Layout storage layout = ERC721Storage.layout();
         return layout.owners[owner].balance;
     }
 
-    function numberMinted(address owner) public view returns (uint256) {
+    function _numberMinted(address owner) internal view returns (uint256) {
         ERC721Storage.Layout storage layout = ERC721Storage.layout();
         return layout.owners[owner].numMinted;
     }
 
-    function numberBurned(address owner) public view returns (uint256) {
+    function _numberBurned(address owner) internal view returns (uint256) {
         ERC721Storage.Layout storage layout = ERC721Storage.layout();
         return layout.owners[owner].numBurned;
     }
 
     // token values
 
-    function ownerOf(uint256 tokenId) public view virtual returns (address) {
+    function _ownerOf(uint256 tokenId) internal view returns (address) {
         return _batchMarkerDataOf(tokenId).owner; // reverts if token not owned
     }
 
@@ -110,14 +110,14 @@ abstract contract ERC721Internal is Initializable, IERC721Internal {
 
     // approvals
 
-    function getApproved(uint256 tokenId) public view virtual returns (address) {
+    function _getApproved(uint256 tokenId) internal view returns (address) {
         ERC721Storage.Layout storage layout = ERC721Storage.layout();
         if (!_exists(tokenId)) revert ApprovalQueryForNonexistentToken();
 
         return layout.tokenApprovals[tokenId];
     }
 
-    function isApprovedForAll(address owner, address operator) public view virtual returns (bool) {
+    function _isApprovedForAll(address owner, address operator) internal view returns (bool) {
         ERC721Storage.Layout storage layout = ERC721Storage.layout();
         return layout.operatorApprovals[owner][operator];
     }
@@ -132,10 +132,10 @@ abstract contract ERC721Internal is Initializable, IERC721Internal {
         if (operator == address(0)) {
             revert ApprovalInvalidOperator();
         }
-        address owner = ownerOf(tokenId);
+        address owner = _ownerOf(tokenId);
 
         if (msg.sender != owner) {
-            if (!isApprovedForAll(owner, msg.sender)) {
+            if (!_isApprovedForAll(owner, msg.sender)) {
                 revert ApprovalCallerNotOwnerNorApproved();
             }
         }
@@ -319,9 +319,9 @@ abstract contract ERC721Internal is Initializable, IERC721Internal {
     ====================*/
 
     function _checkCanTransfer(address account, uint256 tokenId) internal virtual {
-        if (ownerOf(tokenId) != msg.sender) {
-            if (!isApprovedForAll(account, msg.sender)) {
-                if (getApproved(tokenId) != msg.sender) {
+        if (_ownerOf(tokenId) != msg.sender) {
+            if (!_isApprovedForAll(account, msg.sender)) {
+                if (_getApproved(tokenId) != msg.sender) {
                     revert TransferCallerNotOwnerNorApproved();
                 }
             }

--- a/src/cores/ERC721/ERC721Rails.sol
+++ b/src/cores/ERC721/ERC721Rails.sol
@@ -106,7 +106,10 @@ contract ERC721Rails is Rails, Ownable, Initializable, TokenMetadata, ERC721, IE
     =============*/
 
     /// @inheritdoc IERC721Rails
-    function mintTo(address recipient, uint256 quantity) external onlyPermission(Operations.MINT) {
+    function mintTo(address recipient, uint256 quantity) 
+        external onlyPermission(Operations.MINT) returns (uint256 mintStartTokenId)
+    {
+        mintStartTokenId = _nextTokenId();
         _safeMint(recipient, quantity);
     }
 

--- a/src/cores/ERC721/interface/IERC721.sol
+++ b/src/cores/ERC721/interface/IERC721.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-interface IERC721Internal {
+interface IERC721 {
     // events
     event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
     event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
@@ -23,30 +23,28 @@ interface IERC721Internal {
     error MintERC2309QuantityExceedsLimit();
     error OwnershipNotInitializedForExtraData();
 
-    // views
-    function totalSupply() external view returns (uint256);
-    function getApproved(uint256 tokenId) external view returns (address operator);
-    function isApprovedForAll(address owner, address operator) external view returns (bool);
+    // ERC721 spec
     function balanceOf(address owner) external view returns (uint256);
     function ownerOf(uint256 tokenId) external view returns (address);
-}
-
-interface IERC721External {
-    // views
-    function name() external view returns (string memory);
-    function symbol() external view returns (string memory);
-    function tokenURI(uint256 tokenId) external view returns (string memory);
-    function supportsInterface(bytes4 interfaceId) external view returns (bool);
-
-    // setters
     function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) external;
     function safeTransferFrom(address from, address to, uint256 tokenId) external;
     function transferFrom(address from, address to, uint256 tokenId) external;
     function approve(address to, uint256 tokenId) external;
     function setApprovalForAll(address operator, bool approved) external;
-}
+    function getApproved(uint256 tokenId) external view returns (address operator);
+    function isApprovedForAll(address owner, address operator) external view returns (bool);
 
-interface IERC721 is IERC721Internal, IERC721External {}
+    // base
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+    function tokenURI(uint256 tokenId) external view returns (string memory);
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+    function totalSupply() external view returns (uint256);
+    function totalMinted() external view returns (uint256);
+    function totalBurned() external view returns (uint256);
+    function numberMinted(address tokenOwner) external view returns (uint256);
+    function numberBurned(address tokenOwner) external view returns (uint256);
+}
 
 interface IERC721Receiver {
     function onERC721Received(address operator, address from, uint256 tokenId, bytes calldata data)

--- a/src/cores/ERC721/interface/IERC721Rails.sol
+++ b/src/cores/ERC721/interface/IERC721Rails.sol
@@ -6,7 +6,7 @@ interface IERC721Rails {
     /// @dev Function to mint ERC721Rails tokens to a recipient
     /// @param recipient The address of the recipient to receive the minted tokens.
     /// @param quantity The amount of tokens to mint and transfer to the recipient.
-    function mintTo(address recipient, uint256 quantity) external;
+    function mintTo(address recipient, uint256 quantity) external returns (uint256 mintStartTokenId);
 
     /// @dev Burn ERC721Rails tokens from the caller.
     /// @param tokenId The ID of the token to burn from the sender's balance.

--- a/test/cores/ERC721/ERC721.t.sol
+++ b/test/cores/ERC721/ERC721.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import {Test} from "forge-std/Test.sol";
 import {ERC721} from "src/cores/ERC721/ERC721.sol";
-import {IERC721, IERC721Internal} from "src/cores/ERC721/interface/IERC721.sol";
+import {IERC721} from "src/cores/ERC721/interface/IERC721.sol";
 import {ERC721Storage} from "src/cores/ERC721/ERC721Storage.sol";
 import {ERC721Harness} from "test/cores/ERC721/helpers/ERC721Harness.sol";
 import {ERC721ReceiverImplementer} from "test/cores/ERC721/helpers/ERC721ReceiverImplementer.sol";
@@ -41,14 +41,14 @@ contract ERC721Test is Test {
     }
 
     function test_mintRevertZeroQuantity(address to) public {
-        vm.expectRevert(IERC721Internal.MintZeroQuantity.selector);
+        vm.expectRevert(IERC721.MintZeroQuantity.selector);
         erc721.mint(to, 0);
         assertEq(erc721.totalMinted(), 0);
     }
 
     function test_mintRevertZeroAddress(uint8 quantity) public {
         vm.assume(quantity != 0);
-        vm.expectRevert(IERC721Internal.MintToZeroAddress.selector);
+        vm.expectRevert(IERC721.MintToZeroAddress.selector);
         erc721.mint(address(0x0), quantity);
         assertEq(erc721.totalMinted(), 0);
     }
@@ -71,7 +71,7 @@ contract ERC721Test is Test {
         vm.assume(quantity > 0);
 
         address to = address(this); // test contract doesn't implement onERC721Received()
-        err = abi.encodeWithSelector(IERC721Internal.TransferToNonERC721ReceiverImplementer.selector);
+        err = abi.encodeWithSelector(IERC721.TransferToNonERC721ReceiverImplementer.selector);
         vm.expectRevert(err);
         erc721.safeMint(to, quantity);
 
@@ -101,7 +101,7 @@ contract ERC721Test is Test {
             erc721.burn(tokenId);
             assertEq(erc721.totalSupply(), preBurnBalance - (i + 1));
             assertEq(erc721.balanceOf(to), preBurnBalance - (i + 1));
-            vm.expectRevert(IERC721Internal.OwnerQueryForNonexistentToken.selector);
+            vm.expectRevert(IERC721.OwnerQueryForNonexistentToken.selector);
             erc721.ownerOf(tokenId);
         }
         assertEq(erc721.totalBurned(), burnQuantity);
@@ -181,7 +181,7 @@ contract ERC721Test is Test {
 
         uint256 preTransferBalanceFrom = erc721.balanceOf(from);
         uint256 preTransferBalanceTo = erc721.balanceOf(to);
-        err = abi.encodeWithSelector(IERC721Internal.TransferToNonERC721ReceiverImplementer.selector);
+        err = abi.encodeWithSelector(IERC721.TransferToNonERC721ReceiverImplementer.selector);
         // attempt safeTransfers to this address
         for (uint256 i; i < transferQuantity; i++) {
             uint256 tokenId = i;
@@ -242,7 +242,7 @@ contract ERC721Test is Test {
             assertFalse(erc721.isApprovedForAll(from, operator));
 
             // make reverting approval
-            err = abi.encodeWithSelector(IERC721Internal.ApprovalInvalidOperator.selector);
+            err = abi.encodeWithSelector(IERC721.ApprovalInvalidOperator.selector);
             vm.expectRevert(err);
             vm.prank(from);
             erc721.approve(operator, i);
@@ -270,7 +270,7 @@ contract ERC721Test is Test {
             assertFalse(erc721.isApprovedForAll(from, someAddress));
 
             // make reverting approval as someAddress
-            err = abi.encodeWithSelector(IERC721Internal.ApprovalCallerNotOwnerNorApproved.selector);
+            err = abi.encodeWithSelector(IERC721.ApprovalCallerNotOwnerNorApproved.selector);
             vm.expectRevert(err);
             vm.prank(someAddress);
             erc721.approve(operator, i);
@@ -307,7 +307,7 @@ contract ERC721Test is Test {
         // no approval yet
         assertFalse(erc721.isApprovedForAll(from, badOperator));
 
-        err = abi.encodeWithSelector(IERC721Internal.ApprovalInvalidOperator.selector);
+        err = abi.encodeWithSelector(IERC721.ApprovalInvalidOperator.selector);
         vm.expectRevert(err);
         vm.prank(from);
         erc721.setApprovalForAll(badOperator, true);
@@ -413,7 +413,7 @@ contract ERC721Test is Test {
             assertEq(erc721.ownerOf(tokenId), from);
 
             // attempt transferFrom without approval
-            err = abi.encodeWithSelector(IERC721Internal.TransferCallerNotOwnerNorApproved.selector);
+            err = abi.encodeWithSelector(IERC721.TransferCallerNotOwnerNorApproved.selector);
             vm.expectRevert(err);
             erc721.transferFrom(from, to, tokenId);
 

--- a/test/cores/ERC721/ERC721Rails.t.sol
+++ b/test/cores/ERC721/ERC721Rails.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import {Test} from "forge-std/Test.sol";
 import {ERC1967Proxy} from "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {ERC721Rails} from "src/cores/ERC721/ERC721Rails.sol";
-import {IERC721, IERC721Internal} from "src/cores/ERC721/interface/IERC721.sol";
+import {IERC721} from "src/cores/ERC721/interface/IERC721.sol";
 import {Operations} from "src/lib/Operations.sol";
 import {Permissions} from "src/access/permissions/Permissions.sol";
 import {IPermissions, IPermissionsInternal} from "src/access/permissions/interface/IPermissions.sol";
@@ -193,7 +193,7 @@ contract ERC721RailsTest is Test, MockAccountDeployer {
     function test_mintToRevertZeroQuantity(address to) public {
         vm.assume(to != address(0x0));
 
-        vm.expectRevert(IERC721Internal.MintZeroQuantity.selector);
+        vm.expectRevert(IERC721.MintZeroQuantity.selector);
         vm.prank(owner);
         ERC721RailsProxy.mintTo(to, 0);
 
@@ -204,7 +204,7 @@ contract ERC721RailsTest is Test, MockAccountDeployer {
 
     function test_mintToRevertZeroAddress(uint8 quantity) public {
         vm.assume(quantity != 0);
-        vm.expectRevert(IERC721Internal.MintToZeroAddress.selector);
+        vm.expectRevert(IERC721.MintToZeroAddress.selector);
         vm.prank(owner);
         ERC721RailsProxy.mintTo(address(0x0), quantity);
         assertEq(ERC721RailsProxy.totalMinted(), 0);
@@ -215,7 +215,7 @@ contract ERC721RailsTest is Test, MockAccountDeployer {
         vm.assume(quantity > 0);
 
         address to = address(this); // test contract doesn't implement onERC721Received()
-        err = abi.encodeWithSelector(IERC721Internal.TransferToNonERC721ReceiverImplementer.selector);
+        err = abi.encodeWithSelector(IERC721.TransferToNonERC721ReceiverImplementer.selector);
         vm.expectRevert(err);
         vm.startPrank(owner);
         ERC721RailsProxy.mintTo(to, quantity);
@@ -245,7 +245,7 @@ contract ERC721RailsTest is Test, MockAccountDeployer {
         assertEq(ERC721RailsProxy.totalSupply(), quantity);
         assertEq(ERC721RailsProxy.totalBurned(), 0);
 
-        err = abi.encodeWithSelector(IERC721Internal.OwnerQueryForNonexistentToken.selector);
+        err = abi.encodeWithSelector(IERC721.OwnerQueryForNonexistentToken.selector);
         for (uint32 i; i < quantity;) {
             ++i;
             assertEq(ERC721RailsProxy.ownerOf(i), recipient);
@@ -302,7 +302,7 @@ contract ERC721RailsTest is Test, MockAccountDeployer {
             assertFalse(ERC721RailsProxy.isApprovedForAll(from, operator));
 
             // make reverting approval
-            err = abi.encodeWithSelector(IERC721Internal.ApprovalInvalidOperator.selector);
+            err = abi.encodeWithSelector(IERC721.ApprovalInvalidOperator.selector);
             vm.expectRevert(err);
             vm.prank(from);
             ERC721RailsProxy.approve(operator, i);
@@ -332,7 +332,7 @@ contract ERC721RailsTest is Test, MockAccountDeployer {
             assertFalse(ERC721RailsProxy.isApprovedForAll(from, someAddress));
 
             // make reverting approval as someAddress
-            err = abi.encodeWithSelector(IERC721Internal.ApprovalCallerNotOwnerNorApproved.selector);
+            err = abi.encodeWithSelector(IERC721.ApprovalCallerNotOwnerNorApproved.selector);
             vm.expectRevert(err);
             vm.prank(someAddress);
             ERC721RailsProxy.approve(operator, i);
@@ -374,7 +374,7 @@ contract ERC721RailsTest is Test, MockAccountDeployer {
         // no approval yet
         assertFalse(ERC721RailsProxy.isApprovedForAll(from, badOperator));
 
-        err = abi.encodeWithSelector(IERC721Internal.ApprovalInvalidOperator.selector);
+        err = abi.encodeWithSelector(IERC721.ApprovalInvalidOperator.selector);
         vm.expectRevert(err);
         vm.prank(from);
         ERC721RailsProxy.setApprovalForAll(badOperator, true);
@@ -487,7 +487,7 @@ contract ERC721RailsTest is Test, MockAccountDeployer {
             assertEq(ERC721RailsProxy.ownerOf(tokenId), from);
 
             // attempt transferFrom without approval
-            err = abi.encodeWithSelector(IERC721Internal.TransferCallerNotOwnerNorApproved.selector);
+            err = abi.encodeWithSelector(IERC721.TransferCallerNotOwnerNorApproved.selector);
             vm.expectRevert(err);
             ERC721RailsProxy.transferFrom(from, to, tokenId);
 


### PR DESCRIPTION
Refactor ERC721 inheritance structure

- Collapsed IERC721External into IERC721
- Moved exposed external functions from ERC721Internal into ERC721
- Added internal functions to ERC721Internal to maintain functionality and improve readability
- Added `mintStartTokenId` return parameter to `ERC721Rails::mintTo()`
- Updated test files accordingly