### PR TITLE
Enable contract signers

### DIFF
--- a/src/cores/ERC721Account/ERC721AccountRails.sol
+++ b/src/cores/ERC721Account/ERC721AccountRails.sol
@@ -73,23 +73,6 @@ contract ERC721AccountRails is AccountRails, ERC6551Account, Initializable, IERC
         super._checkSenderIsEntryPoint();
     }
 
-    /// @dev When evaluating signatures that don't contain the `VALIDATOR_FLAG`, authenticate only the owner
-    function _defaultValidateUserOp(UserOperation calldata userOp, bytes32 userOpHash, uint256 /*missingAccountFunds*/ )
-        internal
-        view
-        virtual
-        override
-        returns (bool)
-    {
-        // recover signer address and any error
-        (address signer, ECDSA.RecoverError err) = ECDSA.tryRecover(userOpHash, userOp.signature);
-        // return if signature is malformed
-        if (err != ECDSA.RecoverError.NoError) return false;
-
-        // return true only if signer is owner, owner-delegated, or AccountGroup admin
-        return _isAuthorizedForOperation(Operations.ADMIN, signer);
-    }
-
     function _isValidSigner(address signer, bytes memory) internal view override returns (bool) {
         return hasPermission(Operations.CALL, signer);
     }

--- a/src/cores/ERC721Account/ERC721AccountRails.sol
+++ b/src/cores/ERC721Account/ERC721AccountRails.sol
@@ -90,23 +90,6 @@ contract ERC721AccountRails is AccountRails, ERC6551Account, Initializable, IERC
         return _isAuthorizedForOperation(Operations.ADMIN, signer);
     }
 
-    /// @dev When evaluating signatures that don't contain the `VALIDATOR_FLAG`, authenticate only the owner
-    // function _isValidECDSASignature(bytes32 hash, bytes memory signature)
-    //     internal
-    //     view
-    //     virtual
-    //     override
-    //     returns (bool)
-    // {
-    //     // support non-modular signatures by recovering signer address and reverting malleable or invalid signatures
-    //     (address signer, ECDSA.RecoverError err) = ECDSA.tryRecover(hash, signature);
-    //     // return if signature is malformed
-    //     if (err != ECDSA.RecoverError.NoError) return false;
-
-    //     // return true only if signer is owner, owner-delegated, or AccountGroup admin
-    //     return _isAuthorized(Operations.ADMIN, signer);
-    // }
-
     function _isValidSigner(address signer, bytes memory) internal view override returns (bool) {
         return hasPermission(Operations.CALL, signer);
     }

--- a/src/cores/ERC721Account/ERC721AccountRails.sol
+++ b/src/cores/ERC721Account/ERC721AccountRails.sol
@@ -60,7 +60,7 @@ contract ERC721AccountRails is AccountRails, ERC6551Account, Initializable, IERC
 
     /// @inheritdoc Account
     function withdrawFromEntryPoint(address payable recipient, uint256 amount) public virtual override {
-        if (!_isAuthorized(Operations.ADMIN, _msgSender())) {
+        if (!_isAuthorizedForOperation(Operations.ADMIN, _msgSender())) {
             revert IPermissions.PermissionDoesNotExist(Operations.ADMIN, _msgSender());
         }
 
@@ -87,25 +87,25 @@ contract ERC721AccountRails is AccountRails, ERC6551Account, Initializable, IERC
         if (err != ECDSA.RecoverError.NoError) return false;
 
         // return true only if signer is owner, owner-delegated, or AccountGroup admin
-        return _isAuthorized(Operations.ADMIN, signer);
+        return _isAuthorizedForOperation(Operations.ADMIN, signer);
     }
 
     /// @dev When evaluating signatures that don't contain the `VALIDATOR_FLAG`, authenticate only the owner
-    function _defaultIsValidSignature(bytes32 hash, bytes memory signature)
-        internal
-        view
-        virtual
-        override
-        returns (bool)
-    {
-        // support non-modular signatures by recovering signer address and reverting malleable or invalid signatures
-        (address signer, ECDSA.RecoverError err) = ECDSA.tryRecover(hash, signature);
-        // return if signature is malformed
-        if (err != ECDSA.RecoverError.NoError) return false;
+    // function _isValidECDSASignature(bytes32 hash, bytes memory signature)
+    //     internal
+    //     view
+    //     virtual
+    //     override
+    //     returns (bool)
+    // {
+    //     // support non-modular signatures by recovering signer address and reverting malleable or invalid signatures
+    //     (address signer, ECDSA.RecoverError err) = ECDSA.tryRecover(hash, signature);
+    //     // return if signature is malformed
+    //     if (err != ECDSA.RecoverError.NoError) return false;
 
-        // return true only if signer is owner, owner-delegated, or AccountGroup admin
-        return _isAuthorized(Operations.ADMIN, signer);
-    }
+    //     // return true only if signer is owner, owner-delegated, or AccountGroup admin
+    //     return _isAuthorized(Operations.ADMIN, signer);
+    // }
 
     function _isValidSigner(address signer, bytes memory) internal view override returns (bool) {
         return hasPermission(Operations.CALL, signer);
@@ -154,12 +154,19 @@ contract ERC721AccountRails is AccountRails, ERC6551Account, Initializable, IERC
     /// @dev Sensitive account operations restricted to three tiered authorization hierarchy:
     ///   TBA owner || TBA permission || AccountGroup admin
     /// This provides owner autonomy, owner-delegated permissions, and multichain AccountGroup management
-    function _isAuthorized(bytes8 _operation, address _sender) internal view returns (bool) {
+    function _isAuthorizedForOperation(bytes8 _operation, address _sender) internal view returns (bool) {
         // check sender is TBA owner or has been granted relevant permission (or admin) on this account
         if (hasPermission(_operation, _sender)) return true;
 
         // allow AccountGroup admins to manage accounts on non-origin chains
         return _isAccountGroupAdmin(_sender);
+    }
+
+    /// @dev Granting signature authorization can be achieved by adding the `CALL_PERMIT` permission to an account
+    function _isAuthorizedSigner(address _signer) internal view virtual override returns (bool) {
+        if (_isAuthorizedForOperation(Operations.CALL_PERMIT, _signer)) return true;
+
+        return false;
     }
 
     /// @dev On non-origin chains, `owner()` returns the zero address, so multichain upgrades
@@ -174,28 +181,28 @@ contract ERC721AccountRails is AccountRails, ERC6551Account, Initializable, IERC
 
     function _checkCanUpdateValidators() internal virtual override {
         _updateState();
-        if (!_isAuthorized(Operations.VALIDATOR, _msgSender())) {
+        if (!_isAuthorizedForOperation(Operations.VALIDATOR, _msgSender())) {
             revert IPermissions.PermissionDoesNotExist(Operations.VALIDATOR, _msgSender());
         }
     }
 
     function _checkCanUpdatePermissions() internal override {
         _updateState();
-        if (!_isAuthorized(Operations.PERMISSIONS, _msgSender())) {
+        if (!_isAuthorizedForOperation(Operations.PERMISSIONS, _msgSender())) {
             revert IPermissions.PermissionDoesNotExist(Operations.PERMISSIONS, _msgSender());
         }
     }
 
     function _checkCanUpdateGuards() internal override {
         _updateState();
-        if (!_isAuthorized(Operations.GUARDS, _msgSender())) {
+        if (!_isAuthorizedForOperation(Operations.GUARDS, _msgSender())) {
             revert IPermissions.PermissionDoesNotExist(Operations.GUARDS, _msgSender());
         }
     }
 
     function _checkCanUpdateInterfaces() internal override {
         _updateState();
-        if (!_isAuthorized(Operations.INTERFACE, _msgSender())) {
+        if (!_isAuthorizedForOperation(Operations.INTERFACE, _msgSender())) {
             revert IPermissions.PermissionDoesNotExist(Operations.INTERFACE, _msgSender());
         }
     }

--- a/src/cores/account/AccountRails.sol
+++ b/src/cores/account/AccountRails.sol
@@ -116,15 +116,7 @@ abstract contract AccountRails is Account, Rails, Validators, IERC1271 {
 
         // collision of a signature's first 8 bytes with flag is very unlikely; impossible when incl validator address
         if (flag == VALIDATOR_FLAG && isValidator(validator)) {
-            uint256 len = signature.length - prepend;
-            bytes memory formattedSig = new bytes(len); //todo use calldata slice instead
-
-            // copy relevant data into new bytes array, ie `abi.encodePacked(signer, nestedSig)`
-            for (uint256 i; i < len; ++i) {
-                formattedSig[i] = signature[prepend + i];
-            }
-
-            // format call for Validator module
+            bytes calldata formattedSig = signature[prepend:];
             bytes4 ret = IValidator(validator).isValidSignature(hash, formattedSig);
 
             // validator will return either correct `magicValue` or error code `INVALID_SIGNER`

--- a/src/cores/account/AccountRails.sol
+++ b/src/cores/account/AccountRails.sol
@@ -179,16 +179,6 @@ abstract contract AccountRails is Account, Rails, Validators, IERC1271 {
         _valid = SignatureChecker.isValidERC1271SignatureNow(_signer, _hash, _sig);
     }
 
-    /// @dev Function to recover and authenticate a signer address in the context of `validateUserOp()`,
-    /// called only on signatures that were not constructed using the modular verification flag
-    /// @notice Accounts do not express opinion on whether the `signer` is available, ie encoded into `userOp.signature`,
-    /// so the OZ ECDSA library should be used rather than the SignatureChecker
-    function _defaultValidateUserOp(UserOperation calldata userOp, bytes32 userOpHash, uint256 missingAccountFunds)
-        internal
-        view
-        virtual
-        returns (bool);
-
     /// @dev View function to limit callers to only the EntryPoint contract of this chain
     function _checkSenderIsEntryPoint() internal virtual {
         if (msg.sender != entryPoint) revert NotEntryPoint(msg.sender);

--- a/src/cores/account/AccountRails.sol
+++ b/src/cores/account/AccountRails.sol
@@ -12,6 +12,7 @@ import {Operations} from "src/lib/Operations.sol";
 import {Access} from "src/access/Access.sol";
 import {SupportsInterface} from "src/lib/ERC165/SupportsInterface.sol";
 import {ECDSA} from "openzeppelin-contracts/utils/cryptography/ECDSA.sol";
+import {SignatureChecker} from "openzeppelin-contracts/utils/cryptography/SignatureChecker.sol";
 import {IERC1271} from "openzeppelin-contracts/interfaces/IERC1271.sol";
 import {ERC1155Receiver} from "openzeppelin-contracts/token/ERC1155/utils/ERC1155Receiver.sol";
 import {IERC1155Receiver} from "openzeppelin-contracts/token/ERC1155/IERC1155Receiver.sol";
@@ -98,32 +99,29 @@ abstract contract AccountRails is Account, Rails, Validators, IERC1271 {
     /// @dev Function to recover a signer address from the provided hash and signature
     /// and then verify whether the recovered signer address is a recognized Turnkey
     /// @param hash The 32 byte digest derived by hashing signed message data. Sadly, name is canonical in ERC1271.
-    /// @param signature The signature to be verified via recovery. Must be prepended with validator address
-    /// @notice To craft the signature, string concatenation or `abi.encodePacked` *must* be used
+    /// @param signature The signature to be verified via recovery. May be prepended with validator flag and address
+    /// @notice To craft the signature with prepend, string concatenation or `abi.encodePacked` *must* be used
     /// Zero-padded data will fail. Ie: `abi.encodePacked(validatorData, signer, currentRSV)` is correct
     /// @return magicValue The 4-byte value representing signature validity, as defined by EIP1271
     /// Can be one of three values:
     ///   - `this.isValidSignature.selector` indicates a valid signature
     ///   - `bytes4(hex'ffffffff')` indicates a signature failure bubbled up from an external modular validator
     ///   - `bytes4(0)` indicates a default signature failure, ie not using the modular `VALIDATOR_FLAG`
-    function isValidSignature(bytes32 hash, bytes memory signature) public view returns (bytes4 magicValue) {
-        // set start index
-        uint256 start = 0x20;
+    function isValidSignature(bytes32 hash, bytes calldata signature) public view returns (bytes4 magicValue) {
+        // set prepend length
+        uint256 prepend = 0x20;
         // try extracting packed validator data to check for modular validation format
-        bytes32 data;
-        assembly {
-            data := mload(add(signature, start))
-        }
+        bytes32 data = bytes32(signature[:prepend]);
         (bytes8 flag, address validator) = (bytes8(data), address(uint160(uint256(data))));
 
         // collision of a signature's first 8 bytes with flag is very unlikely; impossible when incl validator address
         if (flag == VALIDATOR_FLAG && isValidator(validator)) {
-            uint256 len = signature.length - start;
-            bytes memory formattedSig = new bytes(len);
+            uint256 len = signature.length - prepend;
+            bytes memory formattedSig = new bytes(len); //todo use calldata slice instead
 
             // copy relevant data into new bytes array, ie `abi.encodePacked(signer, nestedSig)`
             for (uint256 i; i < len; ++i) {
-                formattedSig[i] = signature[start + i];
+                formattedSig[i] = signature[prepend + i];
             }
 
             // format call for Validator module
@@ -133,10 +131,18 @@ abstract contract AccountRails is Account, Rails, Validators, IERC1271 {
             magicValue = ret;
         } else {
             // support non-modular signatures by default
-            // authenticate signer using overridden internal func
-            bool validSigner = _defaultIsValidSignature(hash, signature);
-            // return `bytes4(0)` if default signature validation also fails
-            magicValue = validSigner ? this.isValidSignature.selector : bytes4(0);
+            address signer;
+            bool validSig;
+            // check if `v == 0` instead of the standard 27/28, in which case it is a contract signature
+            if (signature[64] == 0) { // todo : move if/else block into  _defaultIsValidSignature() and introduce _isAuthorizedSigner() for returned signer
+                (signer, validSig) = _isValidContractSignature(hash, signature);
+            } else {
+                (signer, validSig) = _isValidECDSASignature(hash, signature);
+            }
+
+            if (validSig && _isAuthorizedSigner(signer)) {
+                magicValue = this.isValidSignature.selector;
+            }
         }
     }
 
@@ -144,11 +150,34 @@ abstract contract AccountRails is Account, Rails, Validators, IERC1271 {
         INTERNALS
     ===============*/
 
-    /// @dev Function to recover and authenticate a signer address in the context of `isValidSignature()`,
+    function _isAuthorizedSigner(address _signer) internal view virtual returns (bool);
+
+    /// @dev Recover and authenticate a signer address in the context of `isValidSignature()`,
     /// called only on signatures that were not constructed using the modular verification flag
     /// @notice Accounts do not express opinion on whether the `signer` is encoded into `userOp.signature`,
     /// so the OZ ECDSA library should be used rather than the SignatureChecker
-    function _defaultIsValidSignature(bytes32 hash, bytes memory signature) internal view virtual returns (bool);
+    function _isValidECDSASignature(bytes32 _hash, bytes memory _signature) internal view virtual returns (address _signer, bool _valid) {
+        // support non-modular signatures by recovering signer address and reverting malleable or invalid signatures
+        ECDSA.RecoverError err;
+        (_signer, err) = ECDSA.tryRecover(_hash, _signature);
+        
+        // return if signature is malformed
+        if (err == ECDSA.RecoverError.NoError) {
+            _valid = true;
+        }
+    }
+
+    /// @dev Smart contract signatures must provide a `v` value of 0 and abi encode the contract signer address into `r`
+    /// as well as provide an `s` value which is the current context's calldata offset where the originator's signature is located
+    /// In short, contract signatures follow this format: `abi.encodePacked(bytes32(signerAddress), uint256(sigOffset), uint8(0), bytes(sig))`
+    function _isValidContractSignature(bytes32 _hash, bytes calldata _signature) internal view virtual returns (address _signer, bool _valid) {
+        // for contract signatures, `_signer` refers to the contract whose address is encoded into `r` rather than signature originator
+        _signer = address(bytes20(_signature[12:32]));
+
+        uint256 offset = uint256(bytes32(_signature[32:64]));
+        bytes calldata _sig = _signature[offset:];
+        _valid = SignatureChecker.isValidERC1271SignatureNow(_signer, _hash, _sig);
+    }
 
     /// @dev Function to recover and authenticate a signer address in the context of `validateUserOp()`,
     /// called only on signatures that were not constructed using the modular verification flag

--- a/src/cores/account/BotAccount.sol
+++ b/src/cores/account/BotAccount.sol
@@ -52,24 +52,6 @@ contract BotAccount is AccountRails, Ownable, Initializable {
     ===============*/
 
     /// @dev When evaluating signatures that don't contain the `VALIDATOR_FLAG`, authenticate only the owner
-    function _defaultValidateUserOp(UserOperation calldata userOp, bytes32 userOpHash, uint256 /*missingAccountFunds*/ )
-        internal
-        view
-        virtual
-        override
-        returns (bool)
-    {
-        // recover signer address and any error
-        (address signer, ECDSA.RecoverError err) = ECDSA.tryRecover(userOpHash, userOp.signature);
-        // return if signature is malformed
-        if (err != ECDSA.RecoverError.NoError) return false;
-        // return if signer is not owner
-        if (signer != owner()) return false;
-
-        return true;
-    }
-
-    /// @dev When evaluating signatures that don't contain the `VALIDATOR_FLAG`, authenticate only the owner
     function _isAuthorizedSigner(address _signer) internal view virtual override returns (bool) {
         if (hasPermission(Operations.CALL_PERMIT, _signer)) return true;
 

--- a/src/cores/account/BotAccount.sol
+++ b/src/cores/account/BotAccount.sol
@@ -70,21 +70,10 @@ contract BotAccount is AccountRails, Ownable, Initializable {
     }
 
     /// @dev When evaluating signatures that don't contain the `VALIDATOR_FLAG`, authenticate only the owner
-    function _defaultIsValidSignature(bytes32 hash, bytes memory signature)
-        internal
-        view
-        virtual
-        override
-        returns (bool)
-    {
-        // support non-modular signatures by recovering signer address and reverting malleable or invalid signatures
-        (address signer, ECDSA.RecoverError err) = ECDSA.tryRecover(hash, signature);
-        // return if signature is malformed
-        if (err != ECDSA.RecoverError.NoError) return false;
-        // return if signer is not owner
-        if (signer != owner()) return false;
+    function _isAuthorizedSigner(address _signer) internal view virtual override returns (bool) {
+        if (hasPermission(Operations.CALL_PERMIT, _signer)) return true;
 
-        return true;
+        return false;
     }
 
     /// @notice This function must be overridden by contracts inheriting `Account` to delineate

--- a/src/validator/CallPermitValidator.sol
+++ b/src/validator/CallPermitValidator.sol
@@ -36,10 +36,8 @@ contract CallPermitValidator is Validator {
 
         // prepend is 20 since only signer remains prepended after processing validator flag
         uint256 prepend = 20;
-        bytes memory signerData = userOp.signature[:prepend];
-        address signer = address((bytes20(signerData)));
-
-        bytes memory nestedSig = userOp.signature[prepend:];
+        address signer = address(bytes20(userOp.signature[:prepend]));
+        bytes calldata nestedSig = userOp.signature[prepend:];
 
         // terminate if recovered signer address does not match packed signer
         if (!SignatureChecker.isValidSignatureNow(signer, userOpHash, nestedSig)) return SIG_VALIDATION_FAILED;

--- a/src/validator/CallPermitValidator.sol
+++ b/src/validator/CallPermitValidator.sol
@@ -34,10 +34,12 @@ contract CallPermitValidator is Validator {
         bytes6 validAfter;
         uint256 successData = uint256(bytes32(abi.encodePacked(authorizer, validUntil, validAfter)));
 
-        bytes memory signerData = userOp.signature[:20];
+        // prepend is 20 since only signer remains prepended after processing validator flag
+        uint256 prepend = 20;
+        bytes memory signerData = userOp.signature[:prepend];
         address signer = address((bytes20(signerData)));
 
-        bytes memory nestedSig = userOp.signature[20:];
+        bytes memory nestedSig = userOp.signature[prepend:];
 
         // terminate if recovered signer address does not match packed signer
         if (!SignatureChecker.isValidSignatureNow(signer, userOpHash, nestedSig)) return SIG_VALIDATION_FAILED;
@@ -57,25 +59,16 @@ contract CallPermitValidator is Validator {
     /// @param signature The signature to be recovered and verified
     /// @notice The top level call context to an `Account` implementation must prepend
     /// an additional 32-byte word packed with the `VALIDATOR_FLAG` and this address
-    function isValidSignature(bytes32 msgHash, bytes memory signature)
+    function isValidSignature(bytes32 msgHash, bytes calldata signature)
         external
         view
         virtual
         returns (bytes4 magicValue)
     {
-        bytes32 signerData;
-        assembly {
-            signerData := mload(add(signature, 0x20))
-        }
-        address signer = address(bytes20(signerData));
-
-        // start is now 20th index since only signer is prepended
-        uint256 start = 20;
-        uint256 len = signature.length - start;
-        bytes memory nestedSig = new bytes(len);
-        for (uint256 i; i < len; ++i) {
-            nestedSig[i] = signature[start + i];
-        }
+        // prepend is 20 since only signer remains prepended after processing validator flag
+        uint256 prepend = 20;
+        address signer = address(bytes20(signature[:prepend]));
+        bytes calldata nestedSig = signature[prepend:];
 
         // use SignatureChecker to evaluate `signer` and `nestedSig`
         bool validSig = SignatureChecker.isValidSignatureNow(signer, msgHash, nestedSig);

--- a/src/validator/OnlyOwnerValidator.sol
+++ b/src/validator/OnlyOwnerValidator.sol
@@ -24,10 +24,12 @@ contract OnlyOwnerValidator is Validator {
         virtual
         returns (uint256 validationData)
     {
-        bytes memory signerData = userOp.signature[:20];
+        // prepend is 20 since only signer remains prepended after processing validator flag
+        uint256 prepend = 20;
+        bytes memory signerData = userOp.signature[:prepend];
         address signer = address((bytes20(signerData)));
 
-        bytes memory nestedSig = userOp.signature[20:];
+        bytes memory nestedSig = userOp.signature[prepend:];
 
         // terminate if recovered signer address does not match packed signer
         if (!SignatureChecker.isValidSignatureNow(signer, userOpHash, nestedSig)) return SIG_VALIDATION_FAILED;
@@ -44,25 +46,16 @@ contract OnlyOwnerValidator is Validator {
     /// @param signature The signature to be recovered and verified
     /// @notice The top level call context to an `Account` implementation must prepend
     /// an additional 32-byte word packed with the `VALIDATOR_FLAG` and this address
-    function isValidSignature(bytes32 msgHash, bytes memory signature)
+    function isValidSignature(bytes32 msgHash, bytes calldata signature)
         external
         view
         virtual
         returns (bytes4 magicValue)
     {
-        bytes32 signerData;
-        assembly {
-            signerData := mload(add(signature, 0x20))
-        }
-        address signer = address(bytes20(signerData));
-
-        // start is now 20th index since only signer is prepended
-        uint256 start = 20;
-        uint256 len = signature.length - start;
-        bytes memory nestedSig = new bytes(len);
-        for (uint256 i; i < len; ++i) {
-            nestedSig[i] = signature[start + i];
-        }
+        // prepend is 20 since only signer remains prepended after processing validator flag
+        uint256 prepend = 20;
+        address signer = address(bytes20(signature[:prepend]));
+        bytes calldata nestedSig = signature[prepend:];
 
         // use SignatureChecker to evaluate `signer` and `nestedSig`
         bool validSig = SignatureChecker.isValidSignatureNow(signer, msgHash, nestedSig);

--- a/src/validator/OnlyOwnerValidator.sol
+++ b/src/validator/OnlyOwnerValidator.sol
@@ -26,10 +26,8 @@ contract OnlyOwnerValidator is Validator {
     {
         // prepend is 20 since only signer remains prepended after processing validator flag
         uint256 prepend = 20;
-        bytes memory signerData = userOp.signature[:prepend];
-        address signer = address((bytes20(signerData)));
-
-        bytes memory nestedSig = userOp.signature[prepend:];
+        address signer = address(bytes20(userOp.signature[:prepend]));
+        bytes calldata nestedSig = userOp.signature[prepend:];
 
         // terminate if recovered signer address does not match packed signer
         if (!SignatureChecker.isValidSignatureNow(signer, userOpHash, nestedSig)) return SIG_VALIDATION_FAILED;

--- a/test/cores/ERC721/account/BotAccount.t.sol
+++ b/test/cores/ERC721/account/BotAccount.t.sol
@@ -27,6 +27,8 @@ contract BotAccountTest is Test {
     address public entryPointAddress;
     address public owner;
     address public testTurnkey;
+    address[] turnkeyArray;
+
     UserOperation public userOp;
     bytes32 public userOpHash;
     bytes32 public ethSignedUserOpHash;
@@ -41,9 +43,10 @@ contract BotAccountTest is Test {
         entryPointAddress = 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789;
         owner = vm.addr(0xbeefEEbabe);
         testTurnkey = vm.addr(0xc0ffEEbabe);
+        turnkeyArray.push(testTurnkey);
+
         callPermitValidator = new CallPermitValidator(entryPointAddress);
-        address[] memory turnkeyArray = new address[](1);
-        turnkeyArray[0] = testTurnkey;
+
         userOp = UserOperation({
             sender: testTurnkey,
             nonce: 0,
@@ -368,5 +371,36 @@ contract BotAccountTest is Test {
         vm.prank(entryPointAddress);
         uint256 retUint = botAccount.validateUserOp(newUserOp, newUserOpHash, 0);
         assertEq(retUint, 1); // expect 4337 failure code: 1
+    }
+
+    function test_isValidSignatureFromSmartContract() public {
+        bytes32 contractSignerSalt = bytes32(uint256(salt) + 1);
+        uint256 contractSignerOwnerPrivKey = 0xc0ffee;
+        address contractSignerOwner = vm.addr(contractSignerOwnerPrivKey);
+        BotAccount contractSigner = BotAccount(payable(botAccountFactoryProxy.createBotAccount(contractSignerSalt, contractSignerOwner, address(callPermitValidator), turnkeyArray)));
+
+        assertEq(contractSigner.owner(), contractSignerOwner);
+        assertTrue(contractSigner.hasPermission(Operations.CALL_PERMIT, testTurnkey));
+        
+        // smart contract signature params- v == 0 is used as a flag for contract signatures
+        bytes32 contractSignatureR = bytes32(abi.encode(address(contractSigner))); // encoded signer address (smart contract, not originator)
+        uint256 contractSignatureS = 65; // offset of EOA originator's signature, permissioned on contractSigner via ERC1271
+        uint8 contractSignatureV = 0;
+
+        // sign an example message, ie userOp
+        UserOperation memory newUserOp = userOp;
+        bytes32 newUserOpHash = callPermitValidator.getUserOpHash(newUserOp);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(contractSignerOwnerPrivKey, newUserOpHash);
+        bytes memory originatorSignature = abi.encodePacked(r, s, v);
+
+        bytes memory contractSignature = abi.encodePacked(contractSignatureR, contractSignatureS, contractSignatureV, originatorSignature);
+        
+        // add permission to smart contract signer
+        vm.prank(owner);
+        botAccount.addPermission(Operations.CALL_PERMIT, address(contractSigner));
+
+        bytes4 retVal = botAccount.isValidSignature(newUserOpHash, contractSignature);
+        bytes4 expectedVal = botAccount.isValidSignature.selector;
+        assertEq(retVal, expectedVal);
     }
 }


### PR DESCRIPTION
Added support for smart contract signers in both `isValidSignature()` and `validateUserOp()` for all contracts inheriting from AccountRails

Improved readability and gas optimization by converting `isValidSignature()` parameter to calldata, which allows for slicing rather than memory operations in assembly. This is not strictly outlined by the spec which defines the signature parameter in memory but more modern implementations use calldata for better efficiency and no tradeoff in usability since the function isn't called internally.

Also added test cases to show smart contract signers. Will add one last commit to handle the offset introduced by the validator flag and then should be good to merge after review